### PR TITLE
Fix the encoding of an empty root list, which had a leading space

### DIFF
--- a/src/Data/Aeson/Yaml.hs
+++ b/src/Data/Aeson/Yaml.hs
@@ -91,7 +91,7 @@ encodeBuilder alwaysQuote newlineBeforeObject level value =
       where prefix = bs "\n" <> indent level
     Array vec ->
       if Vector.null vec
-        then bs " []"
+        then bs "[]"
         else mconcat $
              (prefix :) $
              intersperse prefix $
@@ -110,7 +110,7 @@ encodeBuilder alwaysQuote newlineBeforeObject level value =
         , ":"
         , case v of
             Object _ -> ""
-            Array _ -> ""
+            Array xs | not (null xs) -> ""
             _ -> " "
         , encodeBuilder alwaysQuote True (level' + 1) v
         ]

--- a/test/Test/Data/Aeson/Yaml.hs
+++ b/test/Test/Data/Aeson/Yaml.hs
@@ -29,7 +29,16 @@ data TestCase =
     }
 
 testCases :: [TestCase]
-testCases = [tcDataTypes, tcNestedListsAndObjects, tcQuoted]
+testCases = [tcDataTypes, tcNestedListsAndObjects, tcQuoted, tcEmptyList]
+
+tcEmptyList :: TestCase
+tcEmptyList = 
+  TestCase
+    { tcName = "Empty root list"
+    , tcInput = "[]"
+    , tcOutput = "[]\n"
+    , tcAlwaysQuote = False
+    }
 
 tcDataTypes :: TestCase
 tcDataTypes =


### PR DESCRIPTION
Remove the leading space when encoding a root empty list, see https://github.com/dhall-lang/dhall-haskell/issues/1560