### PR TITLE
.cabal: use extra-doc-files

### DIFF
--- a/aeson-yaml.cabal
+++ b/aeson-yaml.cabal
@@ -1,4 +1,4 @@
-cabal-version: 1.12
+cabal-version: 1.18
 
 name:           aeson-yaml
 version:        1.1.0.0
@@ -19,7 +19,7 @@ description:
     This library is pure Haskell, and does not depend on C FFI with libyaml. It
     is also licensed under the BSD3 license.
 
-extra-source-files:
+extra-doc-files:
     README.md
     CHANGELOG.md
 


### PR DESCRIPTION
requires cabal-version 1.18