### PR TITLE
Allow bytestring 0.11

### DIFF
--- a/aeson-yaml.cabal
+++ b/aeson-yaml.cabal
@@ -39,7 +39,7 @@ library
   build-depends:
       aeson >= 0.4.0.0 && < 1.6
     , base >= 4.8.2.0 && < 5
-    , bytestring >= 0.10.4.0 && < 0.11
+    , bytestring >= 0.10.4.0 && < 0.12
     , text >= 0.1 && < 1.3
     , unordered-containers >= 0.1.0.0 && < 0.3
     , vector >= 0.1 && < 0.13

--- a/aeson-yaml.cabal
+++ b/aeson-yaml.cabal
@@ -61,10 +61,10 @@ test-suite test
     -- , hedgehog-gen-json
     , string-qq
     , tasty
-    , tasty-discover
     , tasty-hunit
     , unordered-containers
     , yaml
+  build-tool-depends: tasty-discover:tasty-discover
   type: exitcode-stdio-1.0
   default-language: Haskell2010
 


### PR DESCRIPTION
To test the compatibility with `cabal test -O0 --constraint 'bytestring>=0.11' --allow-newer=bytestring`, I needed to fix the `tasty-discover` dependency. From the commit message:

> Specify tasty-discover dependency as build-tool-depends
>
> Otherwise cabal doesn't know that it needs to build the tasty-discover executable.
>
> Docs: https://cabal.readthedocs.io/en/latest/cabal-package.html?highlight=build-tool#pkg-field-build-tool-depends